### PR TITLE
Dev

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 myname=mesh-front
-install_packages="python-flask iptables-persistent dnsmasq iw"
+install_packages="python-flask iptables-persistent dnsmasq iw build-essential bison flex libgps-dev"
 system_files="/etc/network/interfaces /etc/olsrd/olsrd.conf /etc/olsrd/olsrd.key /etc/default/olsrd /etc/iptables/rules.v4 /etc/hosts /etc/hostname /etc/dnsmasq.d/mesh-front-dnsmasq.conf"
 init="systemd"
 
@@ -35,7 +35,7 @@ do
    fi
 done
 
-# Download and build olrs
+# Download and build olrsd
 if [ ! -e share/olsrd-master.tar.gz ]
 then
    wget https://github.com/OLSR/olsrd/archive/master.tar.gz -O share/olsrd-master.tar.gz
@@ -47,7 +47,6 @@ sudo make install
 make libs
 sudo make libs_install
 cd ..
-rm -rf olsrd-master
 sudo cp install/olsrd.init /etc/init.d/olsrd
 
 # 1. Back up system files.
@@ -124,6 +123,11 @@ fi
 
 # 3. remove access to group
 sudo rm /etc/sudoers.d/mesh-front-sudoers
+
+# 4. remove olsrd
+cd olsrd-master
+sudo make uninstall
+sudo make libs_uninstall
 }
 
 ##################

--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,10 @@ do
 done
 
 # Download and build olrsd
+if [ ! -d share ]
+then
+   mkdir share
+fi
 if [ ! -e share/olsrd-master.tar.gz ]
 then
    wget https://github.com/OLSR/olsrd/archive/master.tar.gz -O share/olsrd-master.tar.gz
@@ -48,6 +52,7 @@ make libs
 sudo make libs_install
 cd ..
 sudo cp install/olsrd.init /etc/init.d/olsrd
+sudo cp install/olsrd.default /etc/default/olsrd
 
 # 1. Back up system files.
 for system_file in $system_files
@@ -75,7 +80,6 @@ sudo usermod -a -G $myname $installuser
 # 4. Add sudo access to group, and other generic install files
 sudo cp install/mesh-front-sudoers /etc/sudoers.d/mesh-front-sudoers
 sudo chmod 440 /etc/sudoers.d/mesh-front-sudoers
-sudo cp install/olsrd.default /etc/default/olsrd
 
 # 5. Open System files to group
 for system_file in $system_files
@@ -128,6 +132,8 @@ sudo rm /etc/sudoers.d/mesh-front-sudoers
 cd olsrd-master
 sudo make uninstall
 sudo make libs_uninstall
+sudo rm /etc/init.d/olsrd
+sudo rm /etc/default/olsrd
 }
 
 ##################

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,14 @@ sudo make libs_install
 cd ..
 sudo cp install/olsrd.init /etc/init.d/olsrd
 sudo cp install/olsrd.default /etc/default/olsrd
+if [ $init = "systemd" ]
+then
+    systemctl enable olsrd
+elif [ $init = "sysV" ]
+then
+    sudo update-rc.d olsrd defaults
+    sudo update-rc.d olsrd enable
+fi
 
 # 1. Back up system files.
 for system_file in $system_files
@@ -129,6 +137,13 @@ fi
 sudo rm /etc/sudoers.d/mesh-front-sudoers
 
 # 4. remove olsrd
+if [ $init = "systemd" ]
+then
+    systemctl disable olsrd
+elif [ $init = "sysV" ]
+then
+    sudo update-rc.d olsrd remove
+fi
 cd olsrd-master
 sudo make uninstall
 sudo make libs_uninstall

--- a/install/olsrd.init
+++ b/install/olsrd.init
@@ -23,7 +23,7 @@
 #       02-Oct-2012
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/sbin/olsrd
+DAEMON=/usr/local/sbin/olsrd
 NAME=olsrd
 DESC=olsrd
 

--- a/templates/olsrd.conf
+++ b/templates/olsrd.conf
@@ -287,7 +287,7 @@ MprCoverage   5
 # Configuration examples for plugins:
 # see /usr/share/doc/olsrd-plugins/ for some for documentation
 
-LoadPlugin "olsrd_jsoninfo.so.0.0"
+LoadPlugin "olsrd_jsoninfo.so.1.1"
 {
     # the default port is 9090 but you can change it like this:
     #PlParam     "port"   "8080"
@@ -321,7 +321,7 @@ LoadPlugin "olsrd_httpinfo.so.0.1"
         PlParam "Resolve" "true"
 }
 
-LoadPlugin "olsrd_nameservice.so.0.3"
+LoadPlugin "olsrd_nameservice.so.0.4"
 {
     PlParam "sighup-pid-file" "/var/run/dnsmasq/dnsmasq.pid"
     PlParam "interval" "30"


### PR DESCRIPTION
Temp fix for https://github.com/JonStratton/mesh-front-py/issues/2 . Both Debian and Ubuntu now build olsrd from source. Ubuntu still is having issues with the main mesh-front-py process (probably due to the Network Manager). But at least olsrd appears to be running on Ubuntu now. Thanks @oblende
